### PR TITLE
Use current intepreter Python tag when building *srepkg*.whl 

### DIFF
--- a/src/srepkg/repackaging_components/wheel_completer_components/cmd_classes.py
+++ b/src/srepkg/repackaging_components/wheel_completer_components/cmd_classes.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools.command.bdist_wheel import bdist_wheel
 
 
@@ -6,7 +7,7 @@ class BdistWheelAbi3(bdist_wheel):
         python, abi, plat = super().get_tag()
 
         if python.startswith("cp"):
-            # on CPython, our wheels are abi3 and compatible back to 3.6
-            return "cp36", "abi3", plat
+            major, minor = sys.version_info[:2]
+            return f"cp{major}{minor}", "abi3", plat
 
         return python, abi, plat


### PR DESCRIPTION
Previously had been hardcoding `cp36` into wheel name.