### PR TITLE
add Python 3.9 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +13,7 @@ authors = [
     { name = "Duane Goodner", email = "dmgoodner@gmail.com" }
 ]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 keywords = []
 classifiers = [
@@ -34,7 +37,7 @@ dependencies = [
     "packaging>=22.0",
     "pkginfo>=1.9.0",
     "requests>=2.28.0",
-    "yaspin>=2.2.0"
+    "yaspin>=2.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/srepkg/wheel_modifier.py
+++ b/src/srepkg/wheel_modifier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 import contextlib
 import os

--- a/test/test_srepkg_builder.py
+++ b/test/test_srepkg_builder.py
@@ -57,7 +57,7 @@ class TestSrepkgBuilder:
             dist_out_contents = list(dist_out_dir.iterdir())
             dist_out_filetypes = [item.suffix for item in dist_out_contents]
             assert (
-                ".zip" in dist_out_filetypes
+                ".gz" in dist_out_filetypes
             ) == condition.srepkg_zip_exists
             assert (
                 ".whl" in dist_out_filetypes


### PR DESCRIPTION
- Python 3.9 does not support pipe operator in type-hints
- Just needed to add `from __future__ import annotations` to each module that was using `|` operator in type-hint.